### PR TITLE
feat: add "Maximum" quality option

### DIFF
--- a/src/controls/settings/useQualitySelector.js
+++ b/src/controls/settings/useQualitySelector.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { usePreferences } from "../usePreferences.js";
 
 const AUTO_QUALITY = { label: "Auto", value: "auto" };
-const MAX_QUALITY = { label: "Maximum", value: "max" };
+const BEST_QUALITY = { label: "Best", value: "best" };
 
 export function useQualitySelector(core) {
   const { savedQuality, setSavedQuality } = usePreferences();
@@ -22,23 +22,23 @@ export function useQualitySelector(core) {
         return;
       }
 
-      if (value === "max") {
-        // "max" is a fake option, resolves to the highest bitrate
-        const maxQuality = qualities[0];
-        if (maxQuality) {
+      if (value === "best") {
+        // "best" is a fake option, resolves to the highest bitrate
+        const bestQuality = qualities[0];
+        if (bestQuality) {
           setSelectedQuality({
-            value: "max",
-            label: maxQuality.name,
+            value: "best",
+            label: `${BEST_QUALITY.label} (${bestQuality.name})`,
           });
           core.setAutoQualityMode(false);
-          core.setQuality(maxQuality);
+          core.setQuality(bestQuality);
         } else {
-          // fallback to auto, keep saved selection as max
-          console.warn("[KickQuality] max quality could not be resolved");
+          // fallback to auto, keep saved selection as "best"
+          console.warn("[KickQuality] best quality could not be resolved");
           setSelectedQuality(AUTO_QUALITY);
           core.setAutoQualityMode(true);
         }
-        setSavedQuality("max");
+        setSavedQuality("best");
         return;
       }
 
@@ -64,7 +64,7 @@ export function useQualitySelector(core) {
 
       if (arg?.key === "qualities") {
         if (arg.value?.length) {
-          // defensive to ensure "max" functionality, `arg.value` should already be sorted
+          // defensive to ensure "best" functionality, `arg.value` should already be sorted
           const sorted = [...arg.value].sort((a, b) => b.bitrate - a.bitrate);
           setQualities(sorted);
         }
@@ -97,7 +97,7 @@ export function useQualitySelector(core) {
       return;
     }
 
-    if (["auto", "max"].includes(savedQuality)) {
+    if (["auto", "best"].includes(savedQuality)) {
       handleQualityChange(savedQuality);
       return;
     }
@@ -109,7 +109,7 @@ export function useQualitySelector(core) {
 
   const qualityOptions = [
     AUTO_QUALITY,
-    MAX_QUALITY,
+    BEST_QUALITY,
     ...qualities.map((q) => ({ value: q.name, label: q.name })),
   ];
 

--- a/src/controls/settings/useQualitySelector.js
+++ b/src/controls/settings/useQualitySelector.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { usePreferences } from "../usePreferences.js";
 
 const AUTO_QUALITY = { label: "Auto", value: "auto" };
+const MAX_QUALITY = { label: "Maximum", value: "max" };
 
 export function useQualitySelector(core) {
   const { savedQuality, setSavedQuality } = usePreferences();
@@ -14,16 +15,34 @@ export function useQualitySelector(core) {
         return;
       }
 
-      const option =
-        value === "auto" ? AUTO_QUALITY : { label: value, value: value };
-
-      setSelectedQuality(option);
-
       if (value === "auto") {
+        setSelectedQuality(AUTO_QUALITY);
         core.setAutoQualityMode(true);
         setSavedQuality("auto");
         return;
       }
+
+      if (value === "max") {
+        // "max" is a fake option, resolves to the highest bitrate
+        const maxQuality = qualities[0];
+        if (maxQuality) {
+          setSelectedQuality({
+            value: "max",
+            label: maxQuality.name,
+          });
+          core.setAutoQualityMode(false);
+          core.setQuality(maxQuality);
+        } else {
+          // fallback to auto, keep saved selection as max
+          console.warn("[KickQuality] max quality could not be resolved");
+          setSelectedQuality(AUTO_QUALITY);
+          core.setAutoQualityMode(true);
+        }
+        setSavedQuality("max");
+        return;
+      }
+
+      setSelectedQuality({ label: value, value: value });
 
       const targetQuality = qualities.find((quality) => quality.name === value);
       if (!targetQuality) {
@@ -45,7 +64,9 @@ export function useQualitySelector(core) {
 
       if (arg?.key === "qualities") {
         if (arg.value?.length) {
-          setQualities(arg.value);
+          // defensive to ensure "max" functionality, `arg.value` should already be sorted
+          const sorted = [...arg.value].sort((a, b) => b.bitrate - a.bitrate);
+          setQualities(sorted);
         }
         return;
       }
@@ -76,8 +97,8 @@ export function useQualitySelector(core) {
       return;
     }
 
-    if (savedQuality === "auto") {
-      handleQualityChange("auto");
+    if (["auto", "max"].includes(savedQuality)) {
+      handleQualityChange(savedQuality);
       return;
     }
 
@@ -88,6 +109,7 @@ export function useQualitySelector(core) {
 
   const qualityOptions = [
     AUTO_QUALITY,
+    MAX_QUALITY,
     ...qualities.map((q) => ({ value: q.name, label: q.name })),
   ];
 


### PR DESCRIPTION
## Motivation

When a user selects a specific quality (e.g. 1080p60) and then swaps to a stream that doesn't offer that exact option (e.g. only has 1080p), the saved quality no longer matches any available option. This causes the player to silently fall back to Auto

## Summary

* Add passthrough quality option that resolves to the max bitrate quality
* Add defensive sort on quality response payload to guarantee functionality
   * Example payload:
```json
{
  "name": "1080p60",
  "group": "chunked",
  "codecs": "avc1.64002A,mp4a.40.2",
  "bitrate": 7075829,
  "width": 1920,
  "height": 1080,
  "framerate": 60,
  "isDefault": true,
  "variantSource": "source",
  "variantId": "",
  "attributes": {
    "Pipeline": "",
    "SourceType": ""
  },
  "sourceGroups": []
}
```




https://github.com/user-attachments/assets/c8c7e7fa-57c1-4bf3-9e6f-6b578af580fc

