### PR TITLE
Retry transient Kick playback URL fetch failures

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,7 +14,7 @@ const userscriptHeader = `// ==UserScript==
 // @author       Destinygg
 // @match        https://player.kick.com/*
 // @grant        none
-// @run-at       document-idle
+// @run-at       document-start
 // @updateURL    https://r2cdn.destiny.gg/kickstiny/kickstiny.user.js
 // @downloadURL  https://r2cdn.destiny.gg/kickstiny/kickstiny.user.js
 // @supportURL   https://github.com/destinygg/kickstiny

--- a/dev/kickstiny-dummy.user.js
+++ b/dev/kickstiny-dummy.user.js
@@ -6,7 +6,7 @@
 // @author       Destinygg
 // @match        https://player.kick.com/*
 // @grant        GM_xmlhttpRequest
-// @run-at       document-idle
+// @run-at       document-start
 // ==/UserScript==
 
 (function () {
@@ -22,7 +22,7 @@
         // Inject the script content directly
         const script = document.createElement("script");
         script.textContent = response.responseText;
-        document.head.appendChild(script);
+        (document.head || document.documentElement).appendChild(script);
       } else {
         console.error(
           "Failed to load script:",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "node build.js --prod",
-    "dev": "concurrently \"node build.js --watch\" \"node dev/http.js\" --names \"build,server\" --prefix-colors \"blue,green\""
+    "dev": "concurrently \"node build.js --watch\" \"node dev/http.js\" --names \"build,server\" --prefix-colors \"blue,green\"",
+    "test": "node --test"
   },
   "dependencies": {
     "@destinygg/libstiny": "^1.8.1",

--- a/src/main.js
+++ b/src/main.js
@@ -3,12 +3,14 @@ import ReactDOM from "react-dom/client";
 import Container from "./controls/container/Container.jsx";
 import { waitForElement } from "./utils/dom.js";
 import { waitForIVSCore } from "./utils/ivs.js";
+import { installPlaybackFetchRetry } from "./utils/playbackFetchRetry.js";
 import mainStyles from "./main.scss";
 
 // Prevent multiple injections
 if (window.__kickQualityExtensionInjected) {
 } else {
   window.__kickQualityExtensionInjected = true;
+  installPlaybackFetchRetry();
 
   (async () => {
     try {

--- a/src/utils/playbackFetchRetry.js
+++ b/src/utils/playbackFetchRetry.js
@@ -1,0 +1,99 @@
+const PLAYBACK_URL_PATH = /^\/api\/v2\/channels\/[^/]+\/playback-url\/?$/;
+const RETRY_DELAYS = [100, 400];
+
+function getRequestUrl(input, baseUrl) {
+  try {
+    const value =
+      typeof input === "string" || input instanceof URL ? input : input?.url;
+    return new URL(value, baseUrl);
+  } catch {
+    return null;
+  }
+}
+
+function isPlaybackUrlRequest(input, init, baseUrl) {
+  const url = getRequestUrl(input, baseUrl);
+  const method = String(init?.method ?? input?.method ?? "GET").toUpperCase();
+
+  return (
+    method === "GET" &&
+    url?.origin === "https://kick.com" &&
+    PLAYBACK_URL_PATH.test(url.pathname)
+  );
+}
+
+function isRetryableStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function wait(delay, signal, setTimeoutRef, clearTimeoutRef) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+
+    const handleAbort = () => {
+      clearTimeoutRef(timer);
+      signal.removeEventListener("abort", handleAbort);
+      reject(signal.reason);
+    };
+    const timer = setTimeoutRef(() => {
+      signal?.removeEventListener("abort", handleAbort);
+      resolve();
+    }, delay);
+
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
+}
+
+export function installPlaybackFetchRetry({
+  windowRef = window,
+  locationRef = window.location,
+  delays = RETRY_DELAYS,
+  setTimeoutRef = setTimeout,
+  clearTimeoutRef = clearTimeout,
+} = {}) {
+  const originalFetch = windowRef.fetch;
+
+  const fetchWithPlaybackRetry = async function (input, init) {
+    if (!isPlaybackUrlRequest(input, init, locationRef.href)) {
+      return originalFetch.call(this, input, init);
+    }
+
+    const signal = init?.signal ?? input?.signal;
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const response = await originalFetch.call(this, input, init);
+        if (
+          attempt >= delays.length ||
+          signal?.aborted ||
+          !isRetryableStatus(response.status)
+        ) {
+          return response;
+        }
+      } catch (error) {
+        if (
+          attempt >= delays.length ||
+          signal?.aborted ||
+          error?.name === "AbortError"
+        ) {
+          throw error;
+        }
+      }
+
+      await wait(delays[attempt], signal, setTimeoutRef, clearTimeoutRef);
+    }
+  };
+
+  windowRef.fetch = fetchWithPlaybackRetry;
+
+  return {
+    disconnect() {
+      if (windowRef.fetch === fetchWithPlaybackRetry) {
+        windowRef.fetch = originalFetch;
+      }
+    },
+  };
+}

--- a/test/playbackFetchRetry.test.js
+++ b/test/playbackFetchRetry.test.js
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { installPlaybackFetchRetry } from "../src/utils/playbackFetchRetry.js";
+
+function immediateTimeout(callback) {
+  callback();
+  return 1;
+}
+
+test("retries a transient playback URL fetch failure", async () => {
+  const responses = [
+    () => Promise.reject(new TypeError("Failed to fetch")),
+    () => Promise.resolve(new Response('{"data":"playback-url"}')),
+  ];
+  const windowRef = {
+    fetch() {
+      return responses.shift()();
+    },
+  };
+
+  installPlaybackFetchRetry({
+    windowRef,
+    locationRef: { href: "https://player.kick.com/channel" },
+    delays: [100],
+    setTimeoutRef: immediateTimeout,
+  });
+
+  const response = await windowRef.fetch(
+    "https://kick.com/api/v2/channels/channel/playback-url",
+    { credentials: "include" },
+  );
+
+  assert.equal(await response.text(), '{"data":"playback-url"}');
+  assert.equal(responses.length, 0);
+});
+
+test("retries a transient server status", async () => {
+  const responses = [
+    new Response("unavailable", { status: 503 }),
+    new Response('{"data":"playback-url"}', { status: 200 }),
+  ];
+  const windowRef = {
+    fetch() {
+      return Promise.resolve(responses.shift());
+    },
+  };
+
+  installPlaybackFetchRetry({
+    windowRef,
+    locationRef: { href: "https://player.kick.com/channel" },
+    delays: [100],
+    setTimeoutRef: immediateTimeout,
+  });
+
+  const response = await windowRef.fetch(
+    "https://kick.com/api/v2/channels/channel/playback-url",
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(responses.length, 0);
+});
+
+test("does not retry unrelated requests", async () => {
+  let calls = 0;
+  const windowRef = {
+    fetch() {
+      calls++;
+      return Promise.reject(new TypeError("Failed to fetch"));
+    },
+  };
+
+  installPlaybackFetchRetry({
+    windowRef,
+    locationRef: { href: "https://player.kick.com/channel" },
+    delays: [100, 400],
+    setTimeoutRef: immediateTimeout,
+  });
+
+  await assert.rejects(
+    windowRef.fetch("https://kick.com/current-viewers"),
+    TypeError,
+  );
+  assert.equal(calls, 1);
+});
+
+test("restores the original fetch implementation on disconnect", () => {
+  const originalFetch = () => Promise.resolve(new Response());
+  const windowRef = { fetch: originalFetch };
+
+  const retry = installPlaybackFetchRetry({
+    windowRef,
+    locationRef: { href: "https://player.kick.com/channel" },
+  });
+  assert.notEqual(windowRef.fetch, originalFetch);
+
+  retry.disconnect();
+  assert.equal(windowRef.fetch, originalFetch);
+});


### PR DESCRIPTION
To be transparent, I've been using GPT-5.5 to debug the "This embed seems to be misconfigured" error that keeps coming up. Eventually it came up with this solution, which seems to work for me. I've been running kickstiny with this code since Friday (2026-06-12) and I haven't had any misconfigured embed errors since then, and I've seen many chatters complaining about getting it since then. The rest of this PR description is generated by GPT-5.5.

## Summary

This adds a small, targeted retry wrapper around `fetch()` for Kick playback URL requests made by the embedded player.

The Kick embed can intermittently replace an otherwise healthy live stream with the fallback message:

> This embed seems to be misconfigured

I have seen this most often after returning to a backgrounded tab. The stream is still live, and reloading the embed usually recovers it. The failures appear to come from transient network/CORS failures while refetching `https://kick.com/api/v2/channels/<channel>/playback-url`.

This PR retries that specific playback URL request before the failure reaches Kick's player code.

## What Changed

- Adds `installPlaybackFetchRetry()`, which wraps `window.fetch`.
- Intercepts only `GET` requests to `https://kick.com/api/v2/channels/<channel>/playback-url`.
- Retries rejected fetches, which covers transient network/CORS failures.
- Also retries retryable HTTP statuses: `408`, `425`, `429`, and `5xx`.
- Uses two short retry delays: `100ms` and `400ms`.
- Does not retry aborted requests.
- Leaves every unrelated request untouched.
- Installs the wrapper before normal Kickstiny initialization.
- Changes the userscript from `document-idle` to `document-start` so the wrapper is installed before Kick's initial playback request and later focus-triggered refetches.
- Updates the dev userscript to work at `document-start` even if `document.head` is not available yet.
- Adds a focused Node test suite for the retry behavior.

## Why This Approach

The failure is intermittent and recoverable. A later request to the same playback URL generally succeeds, so a narrow retry at the fetch boundary prevents the embed from entering its misconfigured fallback state without changing Kickstiny's controls or player behavior.

The wrapper is intentionally scoped to one endpoint and one method. It preserves the original `fetch` call shape for all non-playback requests, and it only retries a bounded number of times.

## Testing

Automated checks run locally:

```bash
npm test
npm run build
npx prettier --check build.js dev/kickstiny-dummy.user.js package.json src/main.js src/utils/playbackFetchRetry.js test/playbackFetchRetry.test.js
git diff --check
```

Manual verification:

- Ran the patched userscript locally for several days.
- Did not reproduce the previous intermittent "This embed seems to be misconfigured" playback failure during that time.

## Notes For Reviewers

The main tradeoff is wrapping global `fetch`, but the wrapper is deliberately conservative:

- Non-playback requests pass through unchanged.
- Non-GET playback requests pass through unchanged.
- Aborted requests stay aborted.
- Retry attempts are bounded to two short delays.
